### PR TITLE
Randomized amplitude, granular actuator params, better docs, refactoring...

### DIFF
--- a/code.py
+++ b/code.py
@@ -71,26 +71,24 @@ for port in mux:
 for driver in drivers:
   if driver:
     # set actuator type
-    feedback = driver._read_u8(0x1A)
     if ACTUATOR_TYPE == "LRA":
-      feedback |= 0x80
+      driver.use_LRM()
     else:
-      feedback &= 0x7F
-    driver._write_u8(0x1A, feedback)
-
-    # run both ERM and LRA in open-loop mode
+      driver.use_ERM()
+    
+    # set open-loop mode (both ERM & LRA)
     control3 = driver._read_u8(0x1D)
     driver._write_u8(0x1D, control3 | 0x21)
 
-    # set OL_CLAMP voltage
+    # set peak voltage
     driver._write_u8(0x17, int(ACTUATOR_VOLTAGE / 0.02122))
 
     # set driving frequency
     driver._write_u8(0x20, int(1 / (ACTUATOR_FREQUENCY * 0.00009849)))
 
     # set initial output amplitude and activate RTP mode
-    driver._write_u8(0x02, 0x00)
-    driver._write_u8(0x01, 0x05)    
+    driver.realtime_value = 0
+    driver.mode = adafruit_drv2605.MODE_REALTIME
 
 while True:
   buzz_sequence(random_sequence())

--- a/code.py
+++ b/code.py
@@ -2,18 +2,39 @@ import adafruit_drv2605
 import adafruit_itertools
 import adafruit_tca9548a
 import board
+import math
 import random
 import time
 
-AMPLITUDE = 127
+"""
+ACTUATOR SPECIFICATIONS: These MUST be set to match the specifications of the
+actuator that you are using.
+"""
+# Type of actuator: "LRA" or "ERM"
+ACTUATOR_TYPE = "LRA"
+# Maximum drive voltage, in V
+ACTUATOR_VOLTAGE = 1.8 * math.sqrt(2)
+# Driving frequency, in Hz
+ACTUATOR_FREQUENCY = 235
+
+"""
+COORDINATED RESET PARAMETERS: These are based on the published research. You are
+free to change them to alter the behaviour of the device.
+"""
+# Vibration amplitude, in % (reduce if the vibration is too intense)
+AMPLITUDE = 100
+# Duration of each vibration and subsequent pause, each in s
+TIME_ON = 0.100
+TIME_OFF = 0.067
+# Duration of the relaxation period between sets of vibrations, in s
+TIME_RELAX = 4 * (TIME_ON + TIME_OFF)
+# Jitter, in %
 JITTER = 23.5
 
-T_ON = 0.100
-T_OFF = 0.067
-T_STEP = T_ON + T_OFF
-T_CR = 4 * T_STEP
-T_JITTER = T_STEP * (JITTER / 100) / 2
+### DO NOT EDIT BELOW THIS LINE UNLESS YOU KNOW WHAT YOU'RE DOING ###
 
+# Precomputed data
+T_JITTER = (TIME_ON + TIME_OFF) * (JITTER / 100) / 2
 PATTERNS_LEFT = list(adafruit_itertools.permutations(range(0, 4)))
 PATTERNS_RIGHT = list(adafruit_itertools.permutations(range(4, 8)))
 
@@ -23,19 +44,19 @@ def random_sequence():
 def fingers_on(fingers):
   for finger in fingers:
     if drivers[finger]:
-      drivers[finger].mode = adafruit_drv2605.MODE_REALTIME
+      drivers[finger].realtime_value = AMPLITUDE
 
 def fingers_off(fingers):
   for finger in fingers:
     if drivers[finger]:
-      drivers[finger].mode = adafruit_drv2605.MODE_INTTRIG
+      drivers[finger].realtime_value = 0
 
 def buzz_sequence(sequence):
   for fingers in sequence:
     fingers_on(fingers)
-    time.sleep(T_ON)
+    time.sleep(TIME_ON)
     fingers_off(fingers)
-    time.sleep(T_OFF + random.uniform(-T_JITTER, T_JITTER))
+    time.sleep(TIME_OFF + random.uniform(-T_JITTER, T_JITTER))
 
 i2c = board.STEMMA_I2C()
 mux = adafruit_tca9548a.TCA9548A(i2c)
@@ -49,12 +70,31 @@ for port in mux:
 
 for driver in drivers:
   if driver:
-    driver.use_LRM()
-    driver.realtime_value = AMPLITUDE
+    # set actuator type
+    feedback = driver._read_u8(0x1A)
+    if ACTUATOR_TYPE == "LRA":
+      feedback |= 0x80
+    else:
+      feedback &= 0x7F
+    driver._write_u8(0x1A, feedback)
+
+    # run both ERM and LRA in open-loop mode
+    control3 = driver._read_u8(0x1D)
+    driver._write_u8(0x1D, control3 | 0x21)
+
+    # set OL_CLAMP voltage
+    driver._write_u8(0x17, int(ACTUATOR_VOLTAGE / 0.02122))
+
+    # set driving frequency
+    driver._write_u8(0x20, int(1 / (ACTUATOR_FREQUENCY * 0.00009849)))
+
+    # set initial output amplitude and activate RTP mode
+    driver._write_u8(0x02, 0x00)
+    driver._write_u8(0x01, 0x05)    
 
 while True:
   buzz_sequence(random_sequence())
   buzz_sequence(random_sequence())
   buzz_sequence(random_sequence())
-  time.sleep(T_CR)
-  time.sleep(T_CR)
+  time.sleep(TIME_RELAX)
+  time.sleep(TIME_RELAX)

--- a/code.py
+++ b/code.py
@@ -21,8 +21,9 @@ ACTUATOR_FREQUENCY = 235
 COORDINATED RESET PARAMETERS: These are based on the published research. You are
 free to change them to alter the behaviour of the device.
 """
-# Vibration amplitude, in % (reduce if the vibration is too intense)
-AMPLITUDE = 100
+# Vibration amplitude range, in %
+AMPLITUDE_MIN = 100
+AMPLITUDE_MAX = 100
 # Duration of each vibration and subsequent pause, each in s
 TIME_ON = 0.100
 TIME_OFF = 0.067
@@ -34,7 +35,7 @@ JITTER = 23.5
 ### DO NOT EDIT BELOW THIS LINE UNLESS YOU KNOW WHAT YOU'RE DOING ###
 
 # Precomputed data
-T_JITTER = (TIME_ON + TIME_OFF) * (JITTER / 100) / 2
+TIME_JITTER = (TIME_ON + TIME_OFF) * (JITTER / 100) / 2
 PATTERNS_LEFT = list(adafruit_itertools.permutations(range(0, 4)))
 PATTERNS_RIGHT = list(adafruit_itertools.permutations(range(4, 8)))
 
@@ -44,7 +45,7 @@ def random_sequence():
 def fingers_on(fingers):
   for finger in fingers:
     if drivers[finger]:
-      drivers[finger].realtime_value = AMPLITUDE
+      drivers[finger].realtime_value = random.randint(AMPLITUDE_MIN, AMPLITUDE_MAX)
 
 def fingers_off(fingers):
   for finger in fingers:
@@ -56,7 +57,7 @@ def buzz_sequence(sequence):
     fingers_on(fingers)
     time.sleep(TIME_ON)
     fingers_off(fingers)
-    time.sleep(TIME_OFF + random.uniform(-T_JITTER, T_JITTER))
+    time.sleep(TIME_OFF + random.uniform(-TIME_JITTER, TIME_JITTER))
 
 i2c = board.STEMMA_I2C()
 mux = adafruit_tca9548a.TCA9548A(i2c)


### PR DESCRIPTION
This PR adds the ability to specify min/max amplitudes and will randomize the amplitude between these levels. It also allows for the use of different actuator types (LRA, ERM)*, and has parameters to specify the details of the specific actuators used. By default, the actuator specified in the parts list is expected.

\* _to achieve this flexibility, this update switches from running the actuators in closed-loop mode with auto-resonance to open-loop mode running at a user-specified frequency. This is especially important for some wide-band LRAs that may not work well with the auto-resonance feature of the haptic driver._